### PR TITLE
Do not use record.serialize, use serializer.serialize(snapshot) instead.

### DIFF
--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -143,12 +143,13 @@ export default DS.Adapter.extend(Ember.Evented, {
     var adapter = this;
     return this.queue.attach(function(resolve, reject) {
       adapter._namespaceForType(type).then (function (namespaceRecords) {
-        var recordHash = snapshot.record.serialize({includeId: true});
+        var serializer = store.serializerFor(type.typeKey);
+        var recordHash = serializer.serialize(snapshot, {includeId: true});
 
-            namespaceRecords.records[recordHash.id] = recordHash;
-            adapter.persistData(type, namespaceRecords).then (function () {
-              resolve();
-            });
+        namespaceRecords.records[recordHash.id] = recordHash;
+        adapter.persistData(type, namespaceRecords).then (function () {
+          resolve();
+        });
       });
     });
   },
@@ -157,10 +158,11 @@ export default DS.Adapter.extend(Ember.Evented, {
     var adapter = this;
     return this.queue.attach(function(resolve, reject) {
       adapter._namespaceForType(type).then (function (namespaceRecords) {
-           var id = snapshot.id;
+        var id = snapshot.id;
+        var serializer = store.serializerFor(type.typeKey);
+        var recordHash = serializer.serialize(snapshot, {includeId: true});
 
-        namespaceRecords.records[id] = snapshot.record.serialize({ includeId: true });
-
+        namespaceRecords.records[id] = recordHash;
         adapter.persistData(type, namespaceRecords).then (function () {
           resolve();
         });

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -139,36 +139,9 @@ export default DS.Adapter.extend(Ember.Evented, {
     });
   },
 
-  createRecord: function (store, type, snapshot) {
-    var adapter = this;
-    return this.queue.attach(function(resolve, reject) {
-      adapter._namespaceForType(type).then (function (namespaceRecords) {
-        var serializer = store.serializerFor(type.typeKey);
-        var recordHash = serializer.serialize(snapshot, {includeId: true});
+  createRecord: updateOrCreate,
 
-        namespaceRecords.records[recordHash.id] = recordHash;
-        adapter.persistData(type, namespaceRecords).then (function () {
-          resolve();
-        });
-      });
-    });
-  },
-
-  updateRecord: function (store, type, snapshot) {
-    var adapter = this;
-    return this.queue.attach(function(resolve, reject) {
-      adapter._namespaceForType(type).then (function (namespaceRecords) {
-        var id = snapshot.id;
-        var serializer = store.serializerFor(type.typeKey);
-        var recordHash = serializer.serialize(snapshot, {includeId: true});
-
-        namespaceRecords.records[id] = recordHash;
-        adapter.persistData(type, namespaceRecords).then (function () {
-          resolve();
-        });
-      });
-    });
-  },
+  updateRecord: updateOrCreate,
 
   deleteRecord: function (store, type, snapshot) {
     var adapter = this;
@@ -504,3 +477,20 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
   }
 });
+
+function updateOrCreate(store, type, snapshot) {
+  var adapter = this;
+  return this.queue.attach(function(resolve, reject) {
+    adapter._namespaceForType(type).then (function (namespaceRecords) {
+      var serializer = store.serializerFor(type.typeKey);
+      var recordHash = serializer.serialize(snapshot, {includeId: true});
+      // update(id comes from snapshot) or create(id comes from serialization)
+      var id = snapshot.id || recordHash.id;
+
+      namespaceRecords.records[id] = recordHash;
+      adapter.persistData(type, namespaceRecords).then (function () {
+        resolve();
+      });
+    });
+  });
+}


### PR DESCRIPTION
We should not use record info, and should use snapshot info when creating, updating, deleting a record.