### PR TITLE
Support embedded relations (embed: always-style)

### DIFF
--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -320,9 +320,9 @@ export default DS.Adapter.extend(Ember.Evented, {
         // For embeddedAlways-style data, we assume the data to be present already, so no further loading is needed.
         if (relationEmbeddedId && !embeddedAlways) {
           if (relationType === 'belongsTo' || relationType === 'hasOne') {
-            promise = adapter.find(null, relationModel, relationEmbeddedId, opts);
+            promise = adapter.find(store, relationModel, relationEmbeddedId, opts);
           } else if (relationType === 'hasMany') {
-            promise = adapter.findMany(null, relationModel, relationEmbeddedId, opts);
+            promise = adapter.findMany(store, relationModel, relationEmbeddedId, opts);
           }
 
           embedPromise = new Ember.RSVP.Promise(function(resolve, reject) {

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -315,8 +315,7 @@ export default DS.Adapter.extend(Ember.Evented, {
          * In this case, cart belongsTo customer and its id is present in the
          * main payload. We find each of these records and add them to _embedded.
          */
-        var serializer = store.serializerFor(type.typeKey);
-        var embeddedAlways = typeof(serializer.hasEmbeddedAlwaysOption) === 'function' && serializer.hasEmbeddedAlwaysOption(relationProp.key);
+        var embeddedAlways = adapter.isEmbeddedAlways(store, type.typeKey, relationProp.key);
 
         // For embeddedAlways-style data, we assume the data to be present already, so no further loading is needed.
         if (relationEmbeddedId && !embeddedAlways) {
@@ -481,6 +480,17 @@ export default DS.Adapter.extend(Ember.Evented, {
     } else {
       return relationships;
     }
+  },
+
+  isEmbeddedAlways: function(store, typeKey, relationKey) {
+    if (store === undefined || store === null) {
+      return false;
+    }
+
+    var serializer = store.serializerFor(typeKey);
+    var embeddedAlways = typeof(serializer.hasEmbeddedAlwaysOption) === 'function' &&
+      serializer.hasEmbeddedAlwaysOption(relationKey);
+    return embeddedAlways;
   }
 });
 

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -316,7 +316,7 @@ export default DS.Adapter.extend(Ember.Evented, {
          * main payload. We find each of these records and add them to _embedded.
          */
         var serializer = store.serializerFor(type.typeKey);
-        var embeddedAlways = typeof(serializer.hasEmbeddedAlwaysOption) == 'function' && serializer.hasEmbeddedAlwaysOption(relationProp.key);
+        var embeddedAlways = typeof(serializer.hasEmbeddedAlwaysOption) === 'function' && serializer.hasEmbeddedAlwaysOption(relationProp.key);
 
         // For embeddedAlways-style data, we assume the data to be present already, so no further loading is needed.
         if (relationEmbeddedId && !embeddedAlways) {

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -95,7 +95,7 @@ export default DS.Adapter.extend(Ember.Evented, {
         var results = adapter.query(namespace.records, query);
 
           if (results.get('length')) {
-            results = adapter.loadRelationshipsForMany(type, results);
+            results = adapter.loadRelationshipsForMany(store, type, results);
           }
 
           resolve(results);

--- a/app/serializers/customer.js
+++ b/app/serializers/customer.js
@@ -4,7 +4,8 @@ import LFSerializer from 'ember-localforage-adapter/serializers/localforage';
 export default LFSerializer.extend(
   DS.EmbeddedRecordsMixin, {
     attrs: {
-      addresses: { embedded: 'always' }
+      addresses: { embedded: 'always' },
+      hour: { embedded: 'always' }
     }
   }
 );

--- a/app/serializers/customer.js
+++ b/app/serializers/customer.js
@@ -1,0 +1,10 @@
+import DS from 'ember-data';
+import LFSerializer from 'ember-localforage-adapter/serializers/localforage';
+
+export default LFSerializer.extend(
+  DS.EmbeddedRecordsMixin, {
+    attrs: {
+      addresses: { embedded: 'always' }
+    }
+  }
+);

--- a/app/serializers/order.js
+++ b/app/serializers/order.js
@@ -1,0 +1,4 @@
+import DS from 'ember-data';
+
+export default DS.RESTSerializer.extend({
+});

--- a/app/serializers/order.js
+++ b/app/serializers/order.js
@@ -1,4 +1,0 @@
-import DS from 'ember-data';
-
-export default DS.RESTSerializer.extend({
-});

--- a/tests/dummy/app/models/address.js
+++ b/tests/dummy/app/models/address.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+
+export default DS.Model.extend({
+  addressNumber: DS.attr()
+});

--- a/tests/dummy/app/models/customer.js
+++ b/tests/dummy/app/models/customer.js
@@ -2,6 +2,6 @@ import DS from 'ember-data';
 
 export default DS.Model.extend({
   customerNumber: DS.Model(),
-  parentCustomer: DS.belongsTo('customer'),
+  hour: DS.belongsTo('hour'),
   addresses: DS.hasMany('address')
 });

--- a/tests/dummy/app/models/customer.js
+++ b/tests/dummy/app/models/customer.js
@@ -4,5 +4,6 @@ var attr = DS.attr;
 var hasMany = DS.hasMany;
 
 export default DS.Model.extend({
+  customerNumber: DS.Model(),
   addresses: hasMany('address')
 });

--- a/tests/dummy/app/models/customer.js
+++ b/tests/dummy/app/models/customer.js
@@ -1,9 +1,7 @@
 import DS from 'ember-data';
 
-var attr = DS.attr;
-var hasMany = DS.hasMany;
-
 export default DS.Model.extend({
   customerNumber: DS.Model(),
-  addresses: hasMany('address')
+  parentCustomer: DS.belongsTo('customer'),
+  addresses: DS.hasMany('address')
 });

--- a/tests/dummy/app/models/customer.js
+++ b/tests/dummy/app/models/customer.js
@@ -1,0 +1,8 @@
+import DS from 'ember-data';
+
+var attr = DS.attr;
+var hasMany = DS.hasMany;
+
+export default DS.Model.extend({
+  addresses: hasMany('address')
+});

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -442,7 +442,7 @@ test('saves hasMany', function() {
 });
 
 test('loads embedded hasMany', function() {
-  expect(1);
+  expect(5);
 
   stop();
 
@@ -450,7 +450,7 @@ test('loads embedded hasMany', function() {
     store.find('customer', '1').then(function(order) {
       var addresses = order.get('addresses');
 
-      equal(addresses.count, 2);
+      equal(addresses.length, 2);
       var address1 = addresses.get('firstObject'),
           address2 = addresses.get('lastObject');
 

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -42,6 +42,18 @@ var FIXTURES = {
       'h3': { id: 'h3', name: 'three', amount: 2, order: 'o3' },
       'h4': { id: 'h4', name: 'four', amount: 1, order: 'o3' }
     }
+  },
+
+  'customer': {
+    records: {
+      '1': {
+        id: '1',
+        addresses: [
+          { id: '1', addressNumber: '12345' },
+          { id: '2', addressNumber: '54321' }
+        ]
+      }
+    }
   }
 };
 
@@ -429,5 +441,31 @@ test('saves hasMany', function() {
   });
 });
 
+test('loads embedded hasMany', function() {
+  expect(1);
+
+  stop();
+
+  run(function() {
+    store.find('customer', '1').then(function(order) {
+      var addresses = order.get('addresses');
+
+      equal(addresses.count, 2);
+      var address1 = addresses.get('firstObject'),
+          address2 = addresses.get('lastObject');
+
+      equal(get(address1, 'id'), '1',
+        'first address id is loaded correctly');
+      equal(get(address1, 'addressNumber'), '12345',
+        'first address number is loaded correctly');
+      equal(get(address2, 'id'), '2',
+        'first address id is loaded correctly');
+      equal(get(address2, 'addressNumber'), '54321',
+        'first address number is loaded correctly');
+
+      start();
+    });
+  });
+});
 
 

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -467,3 +467,34 @@ test("loads embedded hasMany in a 'find with id' operation", function() {
     });
   });
 });
+
+
+test("loads embedded hasMany in a 'find all' operation", function() {
+  expect(6);
+
+  stop();
+
+  run(function() {
+    store.find('customer').then(function(customers) {
+      equal(get(customers, 'length'), 1);
+
+      var customer = customers.objectAt(0);
+      var addresses = customer.get('addresses');
+
+      equal(addresses.length, 2);
+      var address1 = addresses.get('firstObject'),
+          address2 = addresses.get('lastObject');
+
+      equal(get(address1, 'id'), '1',
+        'first address id is loaded correctly');
+      equal(get(address1, 'addressNumber'), '12345',
+        'first address number is loaded correctly');
+      equal(get(address2, 'id'), '2',
+        'first address id is loaded correctly');
+      equal(get(address2, 'addressNumber'), '54321',
+        'first address number is loaded correctly');
+
+      start();
+    });
+  });
+});

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -52,7 +52,11 @@ var FIXTURES = {
         addresses: [
           { id: '1', addressNumber: '12345' },
           { id: '2', addressNumber: '54321' }
-        ]
+        ],
+        hour: {
+          id: 'h5',
+          name: 'five'
+        }
       }
     }
   }
@@ -476,7 +480,7 @@ test("loads embedded hasMany in a 'find all' operation", function() {
 
   run(function() {
     store.find('customer').then(function(customers) {
-      equal(get(customers, 'length'), 1);
+      equal(get(customers, 'length'), 1, 'one customer was retrieved');
 
       var customer = customers.objectAt(0);
       var addresses = customer.get('addresses');
@@ -530,18 +534,18 @@ test("loads embedded hasMany in a 'find many' operation", function() {
 });
 
 test("loads embedded belongsTo in a 'find with id' operation", function() {
-  expect(5);
+  expect(2);
 
   stop();
 
   run(function() {
     store.find('customer', '1').then(function(customer) {
-      var parentCustomer = customer.get('parentCustomer');
+      var hour = customer.get('hour');
 
-     equal(get(parentCustomer, 'id'), '2',
-        'parentCustomer id is loaded correctly');
-      equal(get(parentCustomer, 'customerNumber'), '321',
-        'first address number is loaded correctly');
+     equal(get(hour, 'id'), 'h5',
+        'hour id is loaded correctly');
+      equal(get(hour, 'name'), 'five',
+        'hour name is loaded correctly');
 
       start();
     });

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -48,6 +48,7 @@ var FIXTURES = {
     records: {
       '1': {
         id: '1',
+        customerNumber: '123',
         addresses: [
           { id: '1', addressNumber: '12345' },
           { id: '2', addressNumber: '54321' }
@@ -476,6 +477,36 @@ test("loads embedded hasMany in a 'find all' operation", function() {
 
   run(function() {
     store.find('customer').then(function(customers) {
+      equal(get(customers, 'length'), 1);
+
+      var customer = customers.objectAt(0);
+      var addresses = customer.get('addresses');
+
+      equal(addresses.length, 2);
+      var address1 = addresses.get('firstObject'),
+          address2 = addresses.get('lastObject');
+
+      equal(get(address1, 'id'), '1',
+        'first address id is loaded correctly');
+      equal(get(address1, 'addressNumber'), '12345',
+        'first address number is loaded correctly');
+      equal(get(address2, 'id'), '2',
+        'first address id is loaded correctly');
+      equal(get(address2, 'addressNumber'), '54321',
+        'first address number is loaded correctly');
+
+      start();
+    });
+  });
+});
+
+test("loads embedded hasMany in a 'find many' operation", function() {
+  expect(6);
+
+  stop();
+
+  run(function() {
+    store.find('customer', { customerNumber: '123' }).then(function(customers) {
       equal(get(customers, 'length'), 1);
 
       var customer = customers.objectAt(0);

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -441,14 +441,14 @@ test('saves hasMany', function() {
   });
 });
 
-test('loads embedded hasMany', function() {
+test("loads embedded hasMany in a 'find with id' operation", function() {
   expect(5);
 
   stop();
 
   run(function() {
-    store.find('customer', '1').then(function(order) {
-      var addresses = order.get('addresses');
+    store.find('customer', '1').then(function(customer) {
+      var addresses = customer.get('addresses');
 
       equal(addresses.length, 2);
       var address1 = addresses.get('firstObject'),
@@ -467,5 +467,3 @@ test('loads embedded hasMany', function() {
     });
   });
 });
-
-

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -469,7 +469,6 @@ test("loads embedded hasMany in a 'find with id' operation", function() {
   });
 });
 
-
 test("loads embedded hasMany in a 'find all' operation", function() {
   expect(6);
 
@@ -523,6 +522,25 @@ test("loads embedded hasMany in a 'find many' operation", function() {
       equal(get(address2, 'id'), '2',
         'first address id is loaded correctly');
       equal(get(address2, 'addressNumber'), '54321',
+        'first address number is loaded correctly');
+
+      start();
+    });
+  });
+});
+
+test("loads embedded belongsTo in a 'find with id' operation", function() {
+  expect(5);
+
+  stop();
+
+  run(function() {
+    store.find('customer', '1').then(function(customer) {
+      var parentCustomer = customer.get('parentCustomer');
+
+     equal(get(parentCustomer, 'id'), '2',
+        'parentCustomer id is loaded correctly');
+      equal(get(parentCustomer, 'customerNumber'), '321',
         'first address number is loaded correctly');
 
       start();

--- a/tests/unit/serializers/customer-test.js
+++ b/tests/unit/serializers/customer-test.js
@@ -1,0 +1,14 @@
+import {
+  moduleFor,
+  test
+} from 'ember-qunit';
+
+moduleFor('serializer:customer', {
+  // Specify the other units that are required for this test.
+  // needs: ['serializer:foo']
+});
+
+test('it exists', function(assert) {
+  var serializer = this.subject();
+  assert.ok(serializer);
+});

--- a/tests/unit/serializers/customer-test.js
+++ b/tests/unit/serializers/customer-test.js
@@ -4,8 +4,6 @@ import {
 } from 'ember-qunit';
 
 moduleFor('serializer:customer', {
-  // Specify the other units that are required for this test.
-  // needs: ['serializer:foo']
 });
 
 test("it is set up with embedded:always style for the 'addresses' relation", function(assert) {

--- a/tests/unit/serializers/customer-test.js
+++ b/tests/unit/serializers/customer-test.js
@@ -8,7 +8,13 @@ moduleFor('serializer:customer', {
   // needs: ['serializer:foo']
 });
 
-test('it is set up with embedded:always style for the addresses relation', function(assert) {
+test("it is set up with embedded:always style for the 'addresses' relation", function(assert) {
   var serializer = this.subject();
   assert.ok(serializer.hasEmbeddedAlwaysOption('addresses'), 'addresses relation is not set up with embedded:always style');
 });
+
+test("it is not set up with embedded:always style for the 'foo' relation", function(assert) {
+  var serializer = this.subject();
+  assert.ok(!serializer.hasEmbeddedAlwaysOption('foo'), 'foo relation is unexpectedly set up with embedded:always style');
+});
+

--- a/tests/unit/serializers/customer-test.js
+++ b/tests/unit/serializers/customer-test.js
@@ -8,7 +8,7 @@ moduleFor('serializer:customer', {
   // needs: ['serializer:foo']
 });
 
-test('it exists', function(assert) {
+test('it is set up with embedded:always style for the addresses relation', function(assert) {
   var serializer = this.subject();
-  assert.ok(serializer);
+  assert.ok(serializer.hasEmbeddedAlwaysOption('addresses'), 'addresses relation is not set up with embedded:always style');
 });


### PR DESCRIPTION
Hi,

As promised in #22, here is a PR that adds support for `embedded: 'always'` style data.

I have also added the accompanying tests, and an example of how to set up the serializer for these cases.

Questions/suggestions? Let me know. All tests are green of course, and I will start using this in our own app now (since everything seems to work correctly).

Without this PR, the adapters causes errors since it tries to load data for relations where the child data is already available, which is obviously a problem.