### PR TITLE
Change readme to reflect new ember-cli addon syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Usage
 Install the addon using ember cli
 
 ```
-ember install:addon ember-localforage-adapter
+ember install ember-localforage-adapter
 ```
 
 Initialize the adapter.


### PR DESCRIPTION
ember-cli has changed the addon install command from `ember install:addon <addon name>` to `ember install <addon name>`.  This just changes the readme to show that.