### PR TITLE
Removes unnecessary new operator

### DIFF
--- a/addon/utils/queue.js
+++ b/addon/utils/queue.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Object.extend ({
 
-  queue : [new Ember.RSVP.resolve()],
+  queue : [Ember.RSVP.resolve()],
 
   attach : function (callback) {
     var self = this;


### PR DESCRIPTION
This more or less just a cosmetic change because in the standard Promise API `.resolve()` is not a constructor. 