### PR TITLE
Ember Data v1.0.0-beta.19.2 support + some upgrades & fixes

### DIFF
--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -35,7 +35,7 @@ export default DS.Adapter.extend(Ember.Evented, {
               allowRecursive = snapshot.allowRecursive;
             }
 
-          var record = Ember.A(namespace.records[id]);
+          var record = namespace.records[id];
           if (!record) {
             reject();
             return;
@@ -290,7 +290,7 @@ export default DS.Adapter.extend(Ember.Evented, {
       relationships = relationships.concat(relationshipNames.hasMany);
 
       relationships.forEach(function(relationName) {
-        var relationModel = type.typeForRelationship(relationName),
+        var relationModel = type.typeForRelationship(relationName, store),
             relationEmbeddedId = record[relationName],
             relationProp  = adapter.relationshipProperties(type, relationName),
             relationType  = relationProp.kind,

--- a/bower.json
+++ b/bower.json
@@ -27,14 +27,14 @@
     "jquery": "^1.11.1",
     "localforage": "~1.2.1",
     "ember": "~1.12.1",
-    "ember-data": "1.0.0-beta.18",
+    "ember-data": "1.0.0-beta.19.2",
     "ember-resolver": "~0.1.14",
-    "loader.js": "ember-cli/loader.js#3.2.0",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "~0.3.3",
+    "loader.js": "ember-cli/loader.js#3.3.0",
+    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.5",
+    "ember-cli-test-loader": "ember-cli/ember-cli-test-loader#0.2.0",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.6",
+    "ember-qunit": "~0.4.10",
     "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1"
+    "qunit": "~1.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.0.2",
-    "ember-cli": "0.2.1",
+    "ember-cli": "^0.2.7",
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "0.0.8",
@@ -28,9 +28,9 @@
     "ember-export-application-global": "^1.0.2",
     "express": "^4.8.5",
     "glob": "^4.0.5",
-    "ember-cli-qunit": "0.3.9",
+    "ember-cli-qunit": "1.0.1",
     "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.18"
+    "ember-data": "1.0.0-beta.19.2"
   },
   "description": "Store your ember application data in Mozilla's localforage.",
   "keywords": [

--- a/tests/integration/display-deep-model-test.js
+++ b/tests/integration/display-deep-model-test.js
@@ -13,13 +13,17 @@ var set = Ember.set;
 
 module('Display deep model', {
   setup: function() {
-    run( function() {
-      window.localforage.setItem('DS.LFAdapter', FIXTURES);
+    stop();
+    run(function() {
+      window.localforage.setItem('DS.LFAdapter', FIXTURES).then(function() {
+        start();
+      });
     });
 
     run( function() {
       App = startApp();
-      store = App.__container__.lookup('store:main');
+      DS._setupContainer(App.registry);
+      store = App.__container__.lookup('service:store');
       adapter = App.__container__.lookup('adapter:application');
       adapter.get('cache').clear();
     });


### PR DESCRIPTION
Hello there,

This PR :
- Supports Ember Data v1.0.0-beta.19.2
- Upgrades some other dependencies
- Fixes a bug in `serializeHasMany` which forced a record to set its relationships before being pushed (test also added)
- Improves `extractSingle` to normalize embedded payload before being pushed
- Fixes test initialization which broke all CRUD tests

This PR is preliminary to support Ember Data V1.13 in order to reduce the gap.

All tests pass.

Regards,

Sébastien