### PR TITLE
Implement `queryRecord` (introduced by Ember 1.13)

### DIFF
--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -94,6 +94,29 @@ test('query', function() {
 });
 
 
+test('queryRecord', function() {
+
+  stop();
+  run(function() {
+    store.queryRecord('list', { name: 'one' }).then(function(list) {
+      equal(get(list, 'id'),   'l1',  'id is loaded correctly');
+      equal(get(list, 'name'), 'one', 'name is loaded correctly');
+      equal(get(list, 'b'),    true,  'b is loaded correctly');
+      equal(get(list, 'day'),    1,  'day is loaded correctly');
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.queryRecord('list', { whatever: "dude" }).catch(function(err) {
+        ok(true, "didn't find record for nonsense");
+        start();
+      }
+    );
+  });
+});
+
 test('findAll', function() {
   expect(7);
 
@@ -312,11 +335,8 @@ test('changes in bulk', function() {
 
       promises.push(
         new Ember.RSVP.Promise(function(resolve, reject) {
-          store.findRecord('list', 'l2').then(
-            function(list) {
-            },
-            function(list) {
-              equal(list, undefined, "Record was deleted successfully");
+          store.findRecord('list', 'l2').catch(function(err) {
+              ok(true, "Record was deleted successfully");
               resolve();
             }
           );


### PR DESCRIPTION
Hello (again),

Not really a compatibility issue, but I thought suggesting an implementation for the new `queryRecord` could help. For now, this implementation returns the first record matching the given query (instead of an array) or reject if not found (instead of an empty array).

Happy to discuss that further if you have another idea of implementation.

I added the related tests.

Regards,

Sébastien