### PR TITLE
Fixes and upgrades for 113

### DIFF
--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -64,9 +64,16 @@ export default DS.Adapter.extend(Ember.Evented, {
     return new Ember.RSVP.Promise((resolve, reject) => {
       this._namespaceForType(type).then(function (namespace) {
         var results = [];
+        var record;
 
         for (var i = 0; i < ids.length; i++) {
-          results.push(Ember.copy(namespace.records[ids[i]]));
+          record = namespace.records[ids[i]];
+          if (record) {
+            results.push(Ember.copy(record));
+          } else {
+            Ember.Logger.warn(
+              'Can\'t find record "' + type + '" with id "' + ids[i] + '"');
+          }
         }
 
         resolve(results);
@@ -352,6 +359,11 @@ export default DS.Adapter.extend(Ember.Evented, {
           embedPromise = new Ember.RSVP.Promise((resolve, reject) => {
             promise.then((relationRecord) => {
               resolve(this.addEmbeddedPayload(record, relationName, relationRecord));
+            }).catch(() => {
+              Ember.Logger.warn(
+                'Model "' + type + '" with id "' + record.id + '" ' +
+                'can\'t find related record "' + relationModel + '" with id "' + relationEmbeddedId + '"');
+              resolve(record);
             });
           });
 

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -163,8 +163,15 @@ export default DS.Adapter.extend(Ember.Evented, {
         for (var id in namespace.records) {
           results.push(Ember.copy(namespace.records[id]));
         }
+
         resolve(results);
       });
+    }).then((records) => {
+      if (records.get('length')) {
+        return this.loadRelationshipsForMany(store, type, records);
+      } else {
+        return records;
+      }
     });
   },
 

--- a/addon/adapters/localforage.js
+++ b/addon/adapters/localforage.js
@@ -60,6 +60,26 @@ export default DS.Adapter.extend(Ember.Evented, {
     });
   },
 
+  findAll: function (store, type) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      this._namespaceForType(type).then(function (namespace) {
+        var results = [];
+
+        for (var id in namespace.records) {
+          results.push(Ember.copy(namespace.records[id]));
+        }
+
+        resolve(results);
+      });
+    }).then((records) => {
+      if (records.get('length')) {
+        return this.loadRelationshipsForMany(store, type, records);
+      } else {
+        return records;
+      }
+    });
+  },
+
   findMany: function (store, type, ids) {
     return new Ember.RSVP.Promise((resolve, reject) => {
       this._namespaceForType(type).then(function (namespace) {
@@ -84,6 +104,22 @@ export default DS.Adapter.extend(Ember.Evented, {
       } else {
         return records;
       }
+    });
+  },
+
+  queryRecord: function (store, type, query) {
+    return new Ember.RSVP.Promise((resolve, reject) => {
+      this._namespaceForType(type).then((namespace) => {
+        var record = this._query(namespace.records, query, true);
+
+        if (record) {
+          resolve(record);
+        } else {
+          reject();
+        }
+      });
+    }).then((record) => {
+      return this.loadRelationships(store, type, record);
     });
   },
 
@@ -112,22 +148,6 @@ export default DS.Adapter.extend(Ember.Evented, {
       } else {
         return records;
       }
-    });
-  },
-
-  queryRecord: function (store, type, query) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      this._namespaceForType(type).then((namespace) => {
-        var record = this._query(namespace.records, query, true);
-
-        if (record) {
-          resolve(record);
-        } else {
-          reject();
-        }
-      });
-    }).then((record) => {
-      return this.loadRelationships(store, type, record);
     });
   },
 
@@ -160,26 +180,6 @@ export default DS.Adapter.extend(Ember.Evented, {
     }
 
     return results;
-  },
-
-  findAll: function (store, type) {
-    return new Ember.RSVP.Promise((resolve, reject) => {
-      this._namespaceForType(type).then(function (namespace) {
-        var results = [];
-
-        for (var id in namespace.records) {
-          results.push(Ember.copy(namespace.records[id]));
-        }
-
-        resolve(results);
-      });
-    }).then((records) => {
-      if (records.get('length')) {
-        return this.loadRelationshipsForMany(store, type, records);
-      } else {
-        return records;
-      }
-    });
   },
 
   createRecord: updateOrCreate,

--- a/addon/serializers/localforage.js
+++ b/addon/serializers/localforage.js
@@ -5,25 +5,33 @@ export default DS.JSONSerializer.extend({
 
   isNewSerializerAPI: true,
 
-  serializeHasMany: function (snapshot, json, relationship) {
+  _shouldSerializeHasMany: function (snapshot, key, relationship) {
+    var relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
+    if (this._mustSerialize(key)) {
+      return true;
+    }
+    return this._canSerialize(key) &&
+      (relationshipType === 'manyToNone' ||
+        relationshipType === 'manyToMany' ||
+        relationshipType === 'manyToOne');
+  },  
+
+  // Omit the unknown hasMany relationships of pushed record
+  // (see https://github.com/emberjs/data/issues/3760)
+  serializeHasMany: function(snapshot, json, relationship) {
     var key = relationship.key;
 
-    if (this._canSerialize(key)) {
-      var payloadKey;
+    if (this._shouldSerializeHasMany(snapshot, key, relationship)) {
+      var hasMany = snapshot.hasMany(key, { ids: true });
+      if (hasMany !== undefined) {
+        // if provided, use the mapping provided by `attrs` in
+        // the serializer
+        var payloadKey = this._getMappedKey(key);
+        if (payloadKey === key && this.keyForRelationship) {
+          payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
+        }
 
-      // if provided, use the mapping provided by `attrs` in
-      // the serializer
-      payloadKey = this._getMappedKey(key);
-      if (payloadKey === key && this.keyForRelationship) {
-        payloadKey = this.keyForRelationship(key, "hasMany", "serialize");
-      }
-
-      var relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
-
-      if (relationshipType === 'manyToNone' ||
-        relationshipType === 'manyToMany' ||
-        relationshipType === 'manyToOne') {
-        json[payloadKey] = snapshot.hasMany(key, {ids: true});
+        json[payloadKey] = hasMany;
         // TODO support for polymorphic manyToNone and manyToMany relationships
       }
     }
@@ -88,6 +96,19 @@ export default DS.JSONSerializer.extend({
 
       delete payload._embedded;
     }
+
+    // Remove the undefined hasMany relationships
+    // (related to https://github.com/emberjs/data/issues/3736, although non
+    // blocking in Ember Data 1.13)
+    var relationshipNames = Ember.get(primaryModelClass, 'relationshipNames');
+    var relationships     = relationshipNames.hasMany;
+
+    relationships.forEach((relationName) => {
+      if (Ember.isNone(payload[relationName])) {
+        delete payload[relationName];
+      }
+    });
+
 
     return payload;
   },

--- a/tests/dummy/app/adapters/author.js
+++ b/tests/dummy/app/adapters/author.js
@@ -1,0 +1,5 @@
+import LFAdapter from 'ember-localforage-adapter/adapters/localforage';
+
+export default LFAdapter.extend({
+  namespace: 'MockAdapter'
+});

--- a/tests/dummy/app/adapters/subscriber.js
+++ b/tests/dummy/app/adapters/subscriber.js
@@ -1,0 +1,5 @@
+import LFAdapter from 'ember-localforage-adapter/adapters/localforage';
+
+export default LFAdapter.extend({
+  namespace: 'MockAdapter'
+});

--- a/tests/dummy/app/models/author.js
+++ b/tests/dummy/app/models/author.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string'),
+});

--- a/tests/dummy/app/models/comment.js
+++ b/tests/dummy/app/models/comment.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  title: DS.attr('string'),
+  post: DS.belongsTo('post', { async: true }),
+  author: DS.belongsTo('author', { async: true })
+});

--- a/tests/dummy/app/models/post.js
+++ b/tests/dummy/app/models/post.js
@@ -1,0 +1,7 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  title: DS.attr('string'),
+  comments: DS.hasMany('comment', { async: true }),
+  subscribers: DS.hasMany('subscriber', { async: true })
+});

--- a/tests/dummy/app/models/subscriber.js
+++ b/tests/dummy/app/models/subscriber.js
@@ -1,0 +1,5 @@
+import DS from 'ember-data';
+
+export default DS.Model.extend({
+  name: DS.attr('string')
+});

--- a/tests/helpers/fixtures/crud.js
+++ b/tests/helpers/fixtures/crud.js
@@ -1,4 +1,24 @@
 export default {
+  'post': {
+    records: {
+      'p1': {
+        id: 'p1',
+        title: 'post #1',
+        comments: ['c1', 'missingComment'],
+        subscribers: ['externalS1', 'missingSubscriber']
+      }
+    }
+  },
+
+  'comment': {
+    records: {
+      'c1': {id: 'c1', title: 'comment #1', post: 'p1' },
+      'c2': {id: 'c2', title: 'comment #2', post: 'missingPost'},
+      'c3': {id: 'c3', title: 'comment #3', post: 'p1', author: 'externalA1' },
+      'c4': {id: 'c4', title: 'comment #3', post: 'p1', author: 'missingAuthor' }
+    }
+  },
+
   'list': {
     records: {
       'l1': {id: 'l1', name: 'one', b: true, items: ['i1', 'i2'], day: 24},

--- a/tests/helpers/fixtures/mock.js
+++ b/tests/helpers/fixtures/mock.js
@@ -1,0 +1,19 @@
+export default {
+  'subscriber': {
+    records: {
+      'externalS1': {
+        id: 'externalS1',
+        name: 'John'
+      }
+    }
+  },
+
+  'author': {
+    records: {
+      'externalA1': {
+        id: 'externalA1',
+        name: 'Jane'
+      }
+    }
+  }
+};

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -301,31 +301,59 @@ test("queryRecord", function() {
 // Relationship loading
 //------------------------------------------------------------------------------
 
+function assertionsForHasManyRelationships(items) {
+  var item1 = items.get('firstObject');
+  var item2 = items.get('lastObject');
+  equal(get(item1, 'id'), 'i1', "first item id is loaded correctly");
+  equal(get(item1, 'name'), 'one', "first item name is loaded correctly");
+  equal(get(item2, 'id'), 'i2', "first item id is loaded correctly");
+  equal(get(item2, 'name'), 'two', "first item name is loaded correctly");
+}
+
 test("load hasMany relationships when finding a single record", function() {
   expect(4);
   stop();
 
   run(function() {
     store.findRecord('list', 'l1').then(function(list) {
-      var items = list.get('items');
-      var item1 = items.get('firstObject');
-      var item2 = items.get('lastObject');
-      equal(get(item1, 'id'), 'i1', "first item id is loaded correctly");
-      equal(get(item1, 'name'), 'one', "first item name is loaded correctly");
-      equal(get(item2, 'id'), 'i2', "first item id is loaded correctly");
-      equal(get(item2, 'name'), 'two', "first item name is loaded correctly");
+      assertionsForHasManyRelationships(list.get('items'));
       start();
     });
   });
 });
 
+test("load hasMany relationships when finding multiple records", function() {
+  expect(4);
+  stop();
+
+  run(function() {
+    store.findAll('list').then(function(lists) {
+      assertionsForHasManyRelationships(lists.get('firstObject.items'));
+      start();
+    });
+  });
+});
+
+function assertionsForBelongsToRelationships(list) {
+  equal(get(list, 'id'), 'l1', "id is loaded correctly");
+  equal(get(list, 'name'), 'one', "name is loaded correctly");
+}
+
 test("load belongsTo relationships when finding a single record", function() {
   stop();
   run(function() {
     store.findRecord('item', 'i1').then(function(item) {
-      var list = item.get('list');
-      equal(get(list, 'id'), 'l1', "id is loaded correctly");
-      equal(get(list, 'name'), 'one', "name is loaded correctly");
+      assertionsForBelongsToRelationships(item.get('list'));
+      start();
+    });
+  });
+});
+
+test("load belongsTo relationships when finding multiple records", function() {
+  stop();
+  run(function() {
+    store.findAll('item').then(function(items) {
+      assertionsForBelongsToRelationships(items.get('firstObject.list'));
       start();
     });
   });

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -1,5 +1,8 @@
 import Ember from 'ember';
-import { test } from 'ember-qunit';
+import {
+  test
+}
+from 'ember-qunit';
 import startApp from '../helpers/start-app';
 import FIXTURES from '../helpers/fixtures/crud';
 
@@ -11,16 +14,16 @@ var run = Ember.run;
 var get = Ember.get;
 var set = Ember.set;
 
-module('CRUD', {
-  setup: function () {
+module("CRUD", {
+  setup: function() {
     stop();
-    run(function () {
-      window.localforage.setItem('DS.LFAdapter', FIXTURES).then(function () {
+    run(function() {
+      window.localforage.setItem('DS.LFAdapter', FIXTURES).then(function() {
         start();
       });
     });
 
-    run(function () {
+    run(function() {
       App = startApp();
       store = App.__container__.lookup('service:store');
       adapter = App.__container__.lookup('adapter:application');
@@ -28,120 +31,137 @@ module('CRUD', {
     });
   },
 
-  teardown: function () {
+  teardown: function() {
     run(App, 'destroy');
   }
 });
 
+// Lifecycle methods
+// -----------------------------------------------------------------------------
 
-test('findRecord with id', function () {
-  expect(4);
-
+test("push", function() {
+  expect(3);
   stop();
-  run(function () {
-    store.findRecord('list', 'l1').then(function (list) {
-      equal(get(list, 'id'), 'l1', 'id is loaded correctly');
-      equal(get(list, 'name'), 'one', 'name is loaded correctly');
-      equal(get(list, 'b'), true, 'b is loaded correctly');
-      equal(get(list, 'day'), 1, 'day is loaded correctly');
-      start();
-    });
-  });
-});
 
-
-test('query', function () {
-
-  stop();
-  run(function () {
-    store.query('list', {name: /one|two/}).then(function (records) {
-      equal(get(records, 'length'), 2, 'found results for /one|two/');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {name: /.+/, id: /l1/}).then(function (records) {
-      equal(get(records, 'length'), 1, 'found results for {name: /.+/, id: /l1/}');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {name: 'one'}).then(function (records) {
-      equal(get(records, 'length'), 1, 'found results for name "one"');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {b: true}).then(function (records) {
-      equal(get(records, 'length'), 1, 'found results for {b: true}');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {name: 'two', b: false}).then(function (records) {
-      equal(get(records, 'length'), 1, 'found results for multiple criteria');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {name: 'four', b: false}).then(function (records) {
-      equal(get(records, 'length'), 0, 'found no results when only criteria matches');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.query('list', {whatever: "dude"}).then(function (records) {
-      equal(get(records, 'length'), 0, 'didn\'t find results for nonsense');
-      start();
-    });
-  });
-});
-
-
-test('queryRecord', function () {
-
-  stop();
-  run(function () {
-    store.queryRecord('list', {name: 'one'}).then(function (list) {
-      equal(get(list, 'id'), 'l1', 'id is loaded correctly');
-      equal(get(list, 'name'), 'one', 'name is loaded correctly');
-      equal(get(list, 'b'), true, 'b is loaded correctly');
-      equal(get(list, 'day'), 1, 'day is loaded correctly');
-      start();
-    });
-  });
-
-  stop();
-  run(function () {
-    store.queryRecord('list', {whatever: "dude"}).catch(function (err) {
-        ok(true, "didn't find record for nonsense");
-        start();
+  run(function() {
+    var list = store.push({
+      type: 'list',
+      id: adapter.generateIdForRecord(),
+      attributes: {
+        name: 'Rambo'
       }
-    );
+    });
+
+    list.save().then(function(record) {
+      return store.query('list', {
+        name: 'Rambo'
+      });
+    }).then(function(records) {
+      var record = records.objectAt(0);
+      equal(get(records, 'length'), 1, "Only Rambo was found");
+      equal(get(record, 'name'), "Rambo", "Correct name");
+      equal(get(record, 'id'), list.id, "Correct, original id");
+      start();
+    });
   });
 });
 
-test('findAll', function () {
+test("createRecord", function() {
+  expect(3);
+  stop();
+
+  run(function() {
+    var list = store.createRecord('list', {
+      name: 'Rambo'
+    });
+
+    list.save().then(function(record) {
+      return store.query('list', {
+        name: 'Rambo'
+      });
+    }).then(function(records) {
+      var record = records.objectAt(0);
+      equal(get(records, 'length'), 1, "Only Rambo was found");
+      equal(get(record, 'name'), "Rambo", "Correct name");
+      equal(get(record, 'id'), list.id, "Correct, original id");
+      start();
+    });
+  });
+});
+
+test("updateRecord", function() {
+  expect(3);
+  stop();
+
+  run(function() {
+    var list = store.createRecord('list', {
+      name: 'Rambo'
+    });
+
+    var UpdateList = function(list) {
+      return store.query('list', {
+        name: 'Rambo'
+      }).then(function(records) {
+        var record = records.objectAt(0);
+        record.set('name', 'Macgyver');
+        return record.save();
+      });
+    };
+
+    var AssertListIsUpdated = function() {
+      return store.query('list', {
+        name: 'Macgyver'
+      }).then(function(records) {
+        var record = records.objectAt(0);
+        equal(get(records, 'length'), 1, "Only one record was found");
+        equal(get(record, 'name'), "Macgyver", "Updated name shows up");
+        equal(get(record, 'id'), list.id, "Correct, original id");
+        start();
+      });
+    };
+
+    list.save().then(UpdateList).then(AssertListIsUpdated);
+  });
+});
+
+test("deleteRecord", function() {
+  expect(2);
+  stop();
+
+  run(function() {
+    var AssertListIsDeleted = function() {
+      return store.query('list', {
+        name: 'one'
+      }).then(function(records) {
+        equal(get(records, 'length'), 0, "No record was found");
+        start();
+      });
+    };
+
+    store.query('list', {
+      name: 'one'
+    }).then(function(lists) {
+      var list = lists.objectAt(0);
+      equal(get(list, "id"), "l1", "Item exists");
+      list.deleteRecord();
+      list.on("didDelete", AssertListIsDeleted);
+      list.save();
+    });
+  });
+});
+
+// Find methods
+// -----------------------------------------------------------------------------
+
+test("findAll", function() {
   expect(7);
 
   stop();
-  run(function () {
-    store.findAll('list').then(function (records) {
-      var firstRecord = records.objectAt(0),
-        secondRecord = records.objectAt(1),
-        thirdRecord = records.objectAt(2);
+  run(function() {
+    store.findAll('list').then(function(records) {
+      var firstRecord = records.objectAt(0);
+      var secondRecord = records.objectAt(1);
+      var thirdRecord = records.objectAt(2);
 
       equal(get(records, 'length'), 3, "3 items were found");
 
@@ -158,32 +178,290 @@ test('findAll', function () {
   });
 });
 
+test("findRecord", function() {
+  expect(4);
 
-test('queryMany', function () {
+  stop();
+  run(function() {
+    store.findRecord('list', 'l1').then(function(list) {
+      equal(get(list, 'id'), 'l1', "id is loaded correctly");
+      equal(get(list, 'name'), 'one', "name is loaded correctly");
+      equal(get(list, 'b'), true, "b is loaded correctly");
+      equal(get(list, 'day'), 1, "day is loaded correctly");
+      start();
+    });
+  });
+});
+
+// Query methods
+// -----------------------------------------------------------------------------
+
+test("query", function() {
+
+  stop();
+  run(function() {
+    store.query('list', {
+      name: /one|two/
+    }).then(function(records) {
+      equal(get(records, 'length'), 2, "found results for /one|two/");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      name: /.+/,
+      id: /l1/
+    }).then(function(records) {
+      equal(get(records, 'length'), 1, "found results for { name: /.+/, id: /l1/ }");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      name: 'one'
+    }).then(function(records) {
+      equal(get(records, 'length'), 1, "found results for name 'one'");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      b: true
+    }).then(function(records) {
+      equal(get(records, 'length'), 1, "found results for { b: true }");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      name: 'two',
+      b: false
+    }).then(function(records) {
+      equal(get(records, 'length'), 1, "found results for multiple criteria");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      name: 'four',
+      b: false
+    }).then(function(records) {
+      equal(get(records, 'length'), 0, "found no results when only criteria matches");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.query('list', {
+      whatever: "dude"
+    }).then(function(records) {
+      equal(get(records, 'length'), 0, "didn't find results for nonsense");
+      start();
+    });
+  });
+});
+
+test("queryRecord", function() {
+
+  stop();
+  run(function() {
+    store.queryRecord('list', {
+      name: 'one'
+    }).then(function(list) {
+      Ember.Logger.debug('LIST', list);
+      equal(get(list, 'id'), 'l1', "id is loaded correctly");
+      equal(get(list, 'name'), 'one', "name is loaded correctly");
+      equal(get(list, 'b'), true, "b is loaded correctly");
+      equal(get(list, 'day'), 1, "day is loaded correctly");
+      start();
+    });
+  });
+
+  stop();
+  run(function() {
+    store.queryRecord('list', {
+      whatever: "dude"
+    }).catch(function(err) {
+      ok(true, "didn't find record for nonsense");
+      start();
+    });
+  });
+});
+
+// Relationship loading
+//------------------------------------------------------------------------------
+
+test("load hasMany relationships when finding a single record", function() {
+  expect(4);
+  stop();
+
+  run(function() {
+    store.findRecord('list', 'l1').then(function(list) {
+      var items = list.get('items');
+      var item1 = items.get('firstObject');
+      var item2 = items.get('lastObject');
+      equal(get(item1, 'id'), 'i1', "first item id is loaded correctly");
+      equal(get(item1, 'name'), 'one', "first item name is loaded correctly");
+      equal(get(item2, 'id'), 'i2', "first item id is loaded correctly");
+      equal(get(item2, 'name'), 'two', "first item name is loaded correctly");
+      start();
+    });
+  });
+});
+
+test("load belongsTo relationships when finding a single record", function() {
+  stop();
+  run(function() {
+    store.findRecord('item', 'i1').then(function(item) {
+      var list = item.get('list');
+      equal(get(list, 'id'), 'l1', "id is loaded correctly");
+      equal(get(list, 'name'), 'one', "name is loaded correctly");
+      start();
+    });
+  });
+});
+
+test("load embedded hasMany relationships when finding a single record", function() {
+  expect(5);
+
+  stop();
+
+  run(function() {
+    store.findRecord('customer', '1').then(function(customer) {
+      var addresses = customer.get('addresses');
+      equal(addresses.length, 2);
+
+      var address1 = addresses.get('firstObject');
+      var address2 = addresses.get('lastObject');
+      equal(get(address1, 'id'), '1',
+        "first address id is loaded correctly");
+      equal(get(address1, 'addressNumber'), '12345',
+        "first address number is loaded correctly");
+      equal(get(address2, 'id'), '2',
+        "first address id is loaded correctly");
+      equal(get(address2, 'addressNumber'), '54321',
+        "first address number is loaded correctly");
+
+      start();
+    });
+  });
+});
+
+test("load embedded hasMany relationships when finding multiple records", function() {
+  expect(6);
+
+  stop();
+
+  run(function() {
+    store.findAll('customer').then(function(customers) {
+      equal(get(customers, 'length'), 1, 'one customer was retrieved');
+
+      var customer = customers.objectAt(0);
+      var addresses = customer.get('addresses');
+      equal(addresses.length, 2);
+
+      var address1 = addresses.get('firstObject');
+      var address2 = addresses.get('lastObject');
+      equal(get(address1, 'id'), '1',
+        "first address id is loaded correctly");
+      equal(get(address1, 'addressNumber'), '12345',
+        "first address number is loaded correctly");
+      equal(get(address2, 'id'), '2',
+        "first address id is loaded correctly");
+      equal(get(address2, 'addressNumber'), '54321',
+        "first address number is loaded correctly");
+
+      start();
+    });
+  });
+});
+
+test("load embedded hasMany relationships when querying multiple records", function() {
+  expect(6);
+
+  stop();
+
+  run(function() {
+    store.query('customer', {
+      customerNumber: '123'
+    }).then(function(customers) {
+      equal(get(customers, 'length'), 1);
+
+      var customer = customers.objectAt(0);
+      var addresses = customer.get('addresses');
+      equal(addresses.length, 2);
+
+      var address1 = addresses.get('firstObject');
+      var address2 = addresses.get('lastObject');
+      equal(get(address1, 'id'), '1',
+        "first address id is loaded correctly");
+      equal(get(address1, 'addressNumber'), '12345',
+        "first address number is loaded correctly");
+      equal(get(address2, 'id'), '2',
+        "first address id is loaded correctly");
+      equal(get(address2, 'addressNumber'), '54321',
+        "first address number is loaded correctly");
+
+      start();
+    });
+  });
+});
+
+test("load embedded belongsTo relationships when finding a single record", function() {
+  expect(2);
+
+  stop();
+
+  run(function() {
+    store.findRecord('customer', '1').then(function(customer) {
+      var hour = customer.get('hour');
+      equal(get(hour, 'id'), 'h5',
+        "hour id is loaded correctly");
+      equal(get(hour, 'name'), 'five',
+        "hour name is loaded correctly");
+
+      start();
+    });
+  });
+});
+
+test("load hasMany relationships when querying multiple records", function() {
   expect(11);
   stop();
-  run(function () {
-    store.query('order', {b: true}).then(function (records) {
-      var firstRecord = records.objectAt(0),
-        secondRecord = records.objectAt(1),
-        thirdRecord = records.objectAt(2);
-
+  run(function() {
+    store.query('order', {
+      b: true
+    }).then(function(records) {
+      var firstRecord = records.objectAt(0);
+      var secondRecord = records.objectAt(1);
+      var thirdRecord = records.objectAt(2);
       equal(get(records, 'length'), 3, "3 orders were found");
       equal(get(firstRecord, 'name'), "one", "First order's name is one");
       equal(get(secondRecord, 'name'), "three", "Second order's name is three");
       equal(get(thirdRecord, 'name'), "four", "Third order's name is four");
-      var firstHours = firstRecord.get('hours'),
-        secondHours = secondRecord.get('hours'),
-        thirdHours = thirdRecord.get('hours');
 
+      var firstHours = firstRecord.get('hours');
+      var secondHours = secondRecord.get('hours');
+      var thirdHours = thirdRecord.get('hours');
       equal(get(firstHours, 'length'), 2, "Order one has two hours");
       equal(get(secondHours, 'length'), 2, "Order three has two hours");
       equal(get(thirdHours, 'length'), 0, "Order four has no hours");
 
-      var hourOne = firstHours.objectAt(0),
-        hourTwo = firstHours.objectAt(1),
-        hourThree = secondHours.objectAt(0),
-        hourFour = secondHours.objectAt(1);
+      var hourOne = firstHours.objectAt(0);
+      var hourTwo = firstHours.objectAt(1);
+      var hourThree = secondHours.objectAt(0);
+      var hourFour = secondHours.objectAt(1);
       equal(get(hourOne, 'amount'), 4, "Hour one has amount of 4");
       equal(get(hourTwo, 'amount'), 3, "Hour two has amount of 3");
       equal(get(hourThree, 'amount'), 2, "Hour three has amount of 2");
@@ -194,128 +472,84 @@ test('queryMany', function () {
   });
 });
 
-test('push', function () {
-  expect(3);
+// Relationship saving
+//------------------------------------------------------------------------------
+
+test("save belongsTo relationships", function() {
+  var listId = 'l2';
+
   stop();
-
-  run(function () {
-    var list = store.push({type: 'list', id: adapter.generateIdForRecord(), attributes: {name: 'Rambo'}});
-
-    list.save().then(function (record) {
-
-
-      store.query('list', {name: 'Rambo'}).then(function (records) {
-        var record = records.objectAt(0);
-
-        equal(get(records, 'length'), 1, "Only Rambo was found");
-        equal(get(record, 'name'), "Rambo", "Correct name");
-        equal(get(record, 'id'), list.id, "Correct, original id");
-        start();
+  run(function() {
+    store.findRecord('list', listId).then(function(list) {
+      var item = store.createRecord('item', {
+        name: 'three thousand'
       });
+      item.set('list', list);
+      return item.save();
+    }).then(function(item) {
+      store.unloadAll('item');
+      return store.findRecord('item', item.get('id'));
+    }).then(function(item) {
+      var list = item.get('list');
+      ok(item.get('list'), "list is present");
+      equal(list.id, listId, "list is retrieved correctly");
+      start();
     });
   });
 });
 
-test('createRecord', function () {
-  expect(3);
+test("save hasMany relationships", function() {
+  var listId = 'l2';
+
   stop();
-
-  run(function () {
-    var list = store.createRecord('list', {name: 'Rambo'});
-
-    list.save().then(function (record) {
-
-
-      store.query('list', {name: 'Rambo'}).then(function (records) {
-        var record = records.objectAt(0);
-
-        equal(get(records, 'length'), 1, "Only Rambo was found");
-        equal(get(record, 'name'), "Rambo", "Correct name");
-        equal(get(record, 'id'), list.id, "Correct, original id");
-        start();
+  run(function() {
+    store.findRecord('list', listId).then(function(list) {
+      var item = store.createRecord('item', {
+        name: 'three thousand'
       });
+      list.get('items').pushObject(item);
+      return item.save().then(function() {
+        return list.save();
+      });
+    }).then(function() {
+      store.unloadAll('list');
+      return store.findRecord('list', listId);
+    }).then(function(list) {
+      var items = list.get('items');
+      var item1 = items.objectAt(0);
+      equal(item1.get('name'), 'three thousand', "item is saved");
+      start();
     });
   });
 });
 
-test('updateRecords', function () {
-  expect(3);
+// Bulk operations
+//------------------------------------------------------------------------------
+
+test("perform multiple changes in bulk", function() {
   stop();
+  run(function() {
 
-  run(function () {
-    var list = store.createRecord('list', {name: 'Rambo'});
-
-    var UpdateList = function (list) {
-      return store.query('list', {name: 'Rambo'}).then(function (records) {
-        var record = records.objectAt(0);
-        record.set('name', 'Macgyver');
-        return record.save();
-      });
-    };
-
-    var AssertListIsUpdated = function () {
-      return store.query('list', {name: 'Macgyver'}).then(function (records) {
-        var record = records.objectAt(0);
-
-        equal(get(records, 'length'), 1, "Only one record was found");
-        equal(get(record, 'name'), "Macgyver", "Updated name shows up");
-        equal(get(record, 'id'), list.id, "Correct, original id");
-
-        start();
-      });
-    };
-
-    list.save().then(UpdateList).then(AssertListIsUpdated);
-  });
-});
-
-
-test('deleteRecord', function () {
-  expect(2);
-  stop();
-
-  run(function () {
-    var AssertListIsDeleted = function () {
-      return store.query('list', {name: 'one'}).then(function (records) {
-        equal(get(records, 'length'), 0, "No record was found");
-        start();
-      });
-    };
-
-    store.query('list', {name: 'one'}).then(function (lists) {
-      var list = lists.objectAt(0);
-
-      equal(get(list, "id"), "l1", "Item exists");
-
-      list.deleteRecord();
-      list.on("didDelete", AssertListIsDeleted);
-      list.save();
-    });
-  });
-});
-
-test('changes in bulk', function () {
-  stop();
-  run(function () {
-
-    var listToUpdate = new Ember.RSVP.Promise(function (resolve, reject) {
-      store.findRecord('list', 'l1').then(function (list) {
+    var listToUpdate = new Ember.RSVP.Promise(function(resolve, reject) {
+      store.findRecord('list', 'l1').then(function(list) {
         list.set('name', 'updated');
-        list.save().then(function () {
+        list.save().then(function() {
           resolve();
         });
       });
     });
 
-    var listToCreate = new Ember.RSVP.Promise(function (resolve, reject) {
-      store.createRecord('list', {name: 'Rambo'}).save().then(function () {
+    var listToCreate = new Ember.RSVP.Promise(function(resolve, reject) {
+      store.createRecord('list', {
+        name: 'Rambo'
+      }).save().then(function() {
         resolve();
       });
     });
 
-    var listToDelete = new Ember.RSVP.Promise(function (resolve, reject) {
-      store.findRecord('list', 'l2').then(function (list) {
-        list.destroyRecord().then(function () {
+    var listToDelete = new Ember.RSVP.Promise(function(resolve, reject) {
+      store.findRecord('list', 'l2').then(function(list) {
+        list.destroyRecord().then(function() {
           resolve();
         });
       });
@@ -327,13 +561,13 @@ test('changes in bulk', function () {
       listToDelete
     ];
 
-    Ember.RSVP.all(promises).then(function () {
+    Ember.RSVP.all(promises).then(function() {
 
       promises = Ember.A();
 
       promises.push(
-        new Ember.RSVP.Promise(function (resolve, reject) {
-          store.findRecord('list', 'l1').then(function (list) {
+        new Ember.RSVP.Promise(function(resolve, reject) {
+          store.findRecord('list', 'l1').then(function(list) {
             equal(get(list, 'name'), 'updated', "Record was updated successfully");
             resolve();
           });
@@ -341,8 +575,10 @@ test('changes in bulk', function () {
       );
 
       promises.push(
-        new Ember.RSVP.Promise(function (resolve, reject) {
-          store.query('list', {name: 'Rambo'}).then(function (lists) {
+        new Ember.RSVP.Promise(function(resolve, reject) {
+          store.query('list', {
+            name: 'Rambo'
+          }).then(function(lists) {
             equal(get(lists, 'length'), 1, "Record was created successfully");
             resolve();
           });
@@ -350,214 +586,17 @@ test('changes in bulk', function () {
       );
 
       promises.push(
-        new Ember.RSVP.Promise(function (resolve, reject) {
-          store.findRecord('list', 'l2').catch(function (err) {
-              ok(true, "Record was deleted successfully");
-              resolve();
-            }
-          );
+        new Ember.RSVP.Promise(function(resolve, reject) {
+          store.findRecord('list', 'l2').catch(function(err) {
+            ok(true, "Record was deleted successfully");
+            resolve();
+          });
         })
       );
 
-      Ember.RSVP.all(promises).then(function () {
+      Ember.RSVP.all(promises).then(function() {
         start();
       });
-    });
-  });
-});
-
-
-test('load hasMany association', function () {
-  expect(4);
-  stop();
-
-  run(function () {
-    store.findRecord('list', 'l1').then(function (list) {
-      var items = list.get('items');
-
-      var item1 = items.get('firstObject'),
-        item2 = items.get('lastObject');
-
-      equal(get(item1, 'id'), 'i1', 'first item id is loaded correctly');
-      equal(get(item1, 'name'), 'one', 'first item name is loaded correctly');
-      equal(get(item2, 'id'), 'i2', 'first item id is loaded correctly');
-      equal(get(item2, 'name'), 'two', 'first item name is loaded correctly');
-
-      start();
-    });
-  });
-});
-
-
-test('load belongsTo association', function () {
-  stop();
-  run(function () {
-    store.findRecord('item', 'i1').then(function (item) {
-      return new Ember.RSVP.Promise(function (resolve) {
-        resolve(get(item, 'list'));
-      });
-    }).then(function (list) {
-      equal(get(list, 'id'), 'l1', "id is loaded correctly");
-      equal(get(list, 'name'), 'one', "name is loaded correctly");
-
-      start();
-    });
-  });
-});
-
-
-test('saves belongsTo', function () {
-  var item,
-    listId = 'l2';
-
-  stop();
-  run(function () {
-    store.findRecord('list', listId).then(function (list) {
-      item = store.createRecord('item', {name: 'three thousand'});
-      item.set('list', list);
-
-      return item.save();
-    }).then(function (item) {
-      store.unloadAll('item');
-      return store.findRecord('item', item.get('id'));
-    }).then(function (item) {
-      var list = item.get('list');
-      ok(item.get('list'), 'list is present');
-      equal(list.id, listId, 'list is retrieved correctly');
-      start();
-    });
-  });
-});
-
-test('saves hasMany', function () {
-  var item, list,
-    listId = 'l2';
-
-  stop();
-
-  run(function () {
-    store.findRecord('list', listId).then(function (list) {
-      item = store.createRecord('item', {name: 'three thousand'});
-      list.get('items').pushObject(item);
-
-      return list.save();
-    }).then(function (list) {
-      return item.save();
-    }).then(function (item) {
-      store.unloadAll('list');
-      return store.findRecord('list', listId);
-    }).then(function (list) {
-      var items = list.get('items'),
-        item1 = items.objectAt(0);
-
-      equal(item1.get('name'), 'three thousand', 'item is saved');
-      start();
-    });
-  });
-});
-
-test("loads embedded hasMany in a 'find with id' operation", function () {
-  expect(5);
-
-  stop();
-
-  run(function () {
-    store.findRecord('customer', '1').then(function (customer) {
-      var addresses = customer.get('addresses');
-
-      equal(addresses.length, 2);
-      var address1 = addresses.get('firstObject'),
-        address2 = addresses.get('lastObject');
-
-      equal(get(address1, 'id'), '1',
-        'first address id is loaded correctly');
-      equal(get(address1, 'addressNumber'), '12345',
-        'first address number is loaded correctly');
-      equal(get(address2, 'id'), '2',
-        'first address id is loaded correctly');
-      equal(get(address2, 'addressNumber'), '54321',
-        'first address number is loaded correctly');
-
-      start();
-    });
-  });
-});
-
-test("loads embedded hasMany in a 'find all' operation", function () {
-  expect(6);
-
-  stop();
-
-  run(function () {
-    store.findAll('customer').then(function (customers) {
-      equal(get(customers, 'length'), 1, 'one customer was retrieved');
-
-      var customer = customers.objectAt(0);
-      var addresses = customer.get('addresses');
-
-      equal(addresses.length, 2);
-      var address1 = addresses.get('firstObject'),
-        address2 = addresses.get('lastObject');
-
-      equal(get(address1, 'id'), '1',
-        'first address id is loaded correctly');
-      equal(get(address1, 'addressNumber'), '12345',
-        'first address number is loaded correctly');
-      equal(get(address2, 'id'), '2',
-        'first address id is loaded correctly');
-      equal(get(address2, 'addressNumber'), '54321',
-        'first address number is loaded correctly');
-
-      start();
-    });
-  });
-});
-
-test("loads embedded hasMany in a 'find many' operation", function () {
-  expect(6);
-
-  stop();
-
-  run(function () {
-    store.query('customer', {customerNumber: '123'}).then(function (customers) {
-      equal(get(customers, 'length'), 1);
-
-      var customer = customers.objectAt(0);
-      var addresses = customer.get('addresses');
-
-      equal(addresses.length, 2);
-      var address1 = addresses.get('firstObject'),
-        address2 = addresses.get('lastObject');
-
-      equal(get(address1, 'id'), '1',
-        'first address id is loaded correctly');
-      equal(get(address1, 'addressNumber'), '12345',
-        'first address number is loaded correctly');
-      equal(get(address2, 'id'), '2',
-        'first address id is loaded correctly');
-      equal(get(address2, 'addressNumber'), '54321',
-        'first address number is loaded correctly');
-
-      start();
-    });
-  });
-});
-
-test("loads embedded belongsTo in a 'find with id' operation", function () {
-  expect(2);
-
-  stop();
-
-  run(function () {
-    store.findRecord('customer', '1').then(function (customer) {
-      var hour = customer.get('hour');
-
-      equal(get(hour, 'id'), 'h5',
-        'hour id is loaded correctly');
-      equal(get(hour, 'name'), 'five',
-        'hour name is loaded correctly');
-
-      start();
     });
   });
 });

--- a/tests/integration/crud-test.js
+++ b/tests/integration/crud-test.js
@@ -279,7 +279,6 @@ test("queryRecord", function() {
     store.queryRecord('list', {
       name: 'one'
     }).then(function(list) {
-      Ember.Logger.debug('LIST', list);
       equal(get(list, 'id'), 'l1', "id is loaded correctly");
       equal(get(list, 'name'), 'one', "name is loaded correctly");
       equal(get(list, 'b'), true, "b is loaded correctly");


### PR DESCRIPTION
This PR includes:

- Clean tests from ELA 2.0
- Workarounds introduced in ELA 2.0 (only one of them is really required, but both are better)
- A fix for `findAll()` which didn't load relationships whereas `findMany()` does (let me know whether it was on purpose or not)
- Thanks to https://github.com/genkgo/ember-localforage-adapter/commit/e07abfbb5d2813c48f837390c95cf92cd9a0284b (see issue #46), fix the loading of missing relationships (related to issue #45)
- Leveling some code patterns
- New tests for all of it

About issue #45, here are the 2 groups of 2 cases this PR covers:

1. `hasMany` relationships:
  1. when some of the related records are missing in the localForage
  1. when some of the related records are external to localForage and unreachable
1. `belongsTo` relationships:
  1. when the related record is missing in the localForage
  1. when the related record is external to localForage and unreachable

For the first group of cases, the main record is resolved with its known and reachable related records, others are ignored.

For the second group of cases, the main record is resolved but without the missing or unreachable related records.

All of these cases warns the user in the console.

*Note # 1: In order to mock-up external relationships in the tests, and for the sake of simplicity, I just added a new set of models and fixtures which are loaded in localForage under a dedicated namespace. The corresponding new records, involved in relationships from the main localForage, are loaded by their own adapters (since the fix of #46) and consequently act as they were loaded from elsewhere/anywhere.*

*Note # 2: Some fixes and improvements of this PR can be easily pick to the master branch, except those concerning the loading of the relationships which is now obsolete. I will create another PR for that.*

Thank you for reviewing! :smiley: 