### PR TITLE
_shouldSerializeHasMany was prompted to public API.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "4"
 
 sudo: false
 
@@ -23,7 +23,7 @@ matrix:
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
-  - "npm install -g npm@^2"
+  - "npm install -g npm@^3"
 
 install:
   - npm install -g bower

--- a/addon/serializers/localforage.js
+++ b/addon/serializers/localforage.js
@@ -2,7 +2,7 @@ import DS from 'ember-data';
 
 export default DS.JSONSerializer.extend({
 
-  _shouldSerializeHasMany(snapshot, key, relationship) {
+  shouldSerializeHasMany(snapshot, key, relationship) {
     const relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
 
     if (this._mustSerialize(key)) {

--- a/addon/serializers/localforage.js
+++ b/addon/serializers/localforage.js
@@ -1,6 +1,6 @@
 import DS from 'ember-data';
 
-export default DS.JSONSerializer.extend({
+var Serializer = DS.JSONSerializer.extend({
 
   shouldSerializeHasMany(snapshot, key, relationship) {
     const relationshipType = snapshot.type.determineRelationshipType(relationship, this.store);
@@ -8,10 +8,26 @@ export default DS.JSONSerializer.extend({
     if (this._mustSerialize(key)) {
       return true;
     }
-    
+
     return this._canSerialize(key) &&
       (relationshipType === 'manyToNone' ||
         relationshipType === 'manyToMany' ||
         relationshipType === 'manyToOne');
-  }  
+  }
 });
+
+// Make Serializer compatible with older versions of ember-data.
+// From ember-data 2.12.0 on there is a deprecation for
+// this._shouldSerializeHasMany. The private API has been prompted
+// to public API this.shouldSerializeHasMany. The private API will be
+// removed in ember-data 3.0.0.
+// See https://www.emberjs.com/deprecations/ember-data/v2.x/#toc_jsonserializer-shouldserializehasmany
+if( ! DS.JSONSerializer.prototype.shouldSerializeHasMany ) {
+  Serializer.reopen({
+    _shouldSerializeHasMany( snapshot, key, relationship ){
+      return this.shouldSerializeHasMany( snapshot, key, relationship );
+    }
+  });
+}
+
+export default Serializer;

--- a/tests/dummy/app/models/customer.js
+++ b/tests/dummy/app/models/customer.js
@@ -1,7 +1,7 @@
 import DS from 'ember-data';
 
 export default DS.Model.extend({
-  customerNumber: DS.Model(),
+  customerNumber: DS.attr(),
   hour: DS.belongsTo('hour', { async: false }),
   addresses: DS.hasMany('address', { async: false })
 });


### PR DESCRIPTION
This is fixed the deprecation warning beginning with Ember-data 2.12.

See #70 

Should there be a version dependent option?