### PR TITLE
Remove bower_component "localforage" as dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "6"
+  - "8"
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: node_js
 node_js:
-  - "0.12"
+  - "6"
 
 sudo: false
 

--- a/blueprints/ember-localforage-adapter/index.js
+++ b/blueprints/ember-localforage-adapter/index.js
@@ -3,6 +3,6 @@
 module.exports = {
   normalizeEntityName: function() {},
   afterInstall: function() {
-    return this.addBowerPackageToProject('localforage', '~1.3.1');
+
   }
 };

--- a/blueprints/ember-localforage-adapter/index.js
+++ b/blueprints/ember-localforage-adapter/index.js
@@ -2,7 +2,5 @@
 
 module.exports = {
   normalizeEntityName: function() {},
-  afterInstall: function() {
-
-  }
+  afterInstall: function() {}
 };

--- a/bower.json
+++ b/bower.json
@@ -25,7 +25,7 @@
     "vendor"
   ],
   "dependencies": {
-    "ember": "release",
+    "ember": "2.2.x",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "2.2.x",

--- a/bower.json
+++ b/bower.json
@@ -25,8 +25,7 @@
     "vendor"
   ],
   "dependencies": {
-    "ember": "2.2.x",
-    "localforage": "1.3.x",
+    "ember": "release",
     "ember-cli-shims": "0.0.6",
     "ember-cli-test-loader": "0.2.1",
     "ember-data": "2.2.x",

--- a/index.js
+++ b/index.js
@@ -5,7 +5,6 @@ module.exports = {
   name: 'ember-localforage-adapter',
   included: function included(app) {
     this._super.included(app);
-
-    app.import(app.bowerDirectory + '/localforage/dist/localforage.js');
+    //app.import(app.bowerDirectory + '/localforage/dist/localforage.js');
   }
 };

--- a/index.js
+++ b/index.js
@@ -5,6 +5,5 @@ module.exports = {
   name: 'ember-localforage-adapter',
   included: function included(app) {
     this._super.included(app);
-    //app.import(app.bowerDirectory + '/localforage/dist/localforage.js');
   }
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "ember-cli-uglify": "^1.2.x",
     "ember-cli-uuid": "0.4.1",
     "ember-data": "2.2.x",
-    "localforage": "1.3.x",
+    "localforage": "1.3.3",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-uglify": "^1.2.x",
     "ember-cli-uuid": "0.4.1",
     "ember-data": "2.2.x",
+    "localforage": "1.3.x",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",


### PR DESCRIPTION
When performing `ember install ember-localforage-adapter` it installs a package in the 'bower_components' called 'localforage'. Newer Ember versions are stepping away from Bower since it's discontinued. 

I removed some lines where Bower is needed. The first part when performing `ember try:testall` succeeds in:

 `Built project successfully. Stored in "D:\_GIT\ember-localforage-adapter\tmp\class-tests_dist-7Pqm11YP.tmp".`

But fails in the tests: 

`not ok 16 PhantomJS 2.1 - Cache integration: cache should be unbound data
    ---
        actual: >
            null
        message: >
            beforeEach failed on cache should be unbound data: undefined is not an object (evaluating 'window.localforage.setItem')
        Log: |
    ...
`

Feedback would be greatly appreciated.

(note: this is my first pull request, so it's all pretty new for me)